### PR TITLE
Implement periodic vehicle sync and document limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ Feel free to join the development Discord server [here](https://discord.gg/RjACP
 
 This mod and its source code is licensed under the MIT license.
 
+## Known Limitations
+
+- Population and vehicle movements are not fully synchronized yet.
+- Use `/sync` to reload the save if you notice desyncs.
+- Experimental periodic vehicle position sync tries to reduce drifting.
+
 ## Download & Install
 
 The easiest way to install this mod is from the [Steam Workshop](https://steamcommunity.com/sharedfiles/filedetails/?id=1558438291). Remember to enable it in the content manager.

--- a/src/basegame/CSM.BaseGame.csproj
+++ b/src/basegame/CSM.BaseGame.csproj
@@ -235,6 +235,7 @@
     <Compile Include="Helpers\ArrayXHelper.cs" />
     <Compile Include="Helpers\InfoPanelHelper.cs" />
     <Compile Include="Helpers\ToolSimulator.cs" />
+    <Compile Include="Helpers\VehicleSyncHelper.cs" />
     <Compile Include="Injections\ArrayHandler.cs" />
     <Compile Include="Injections\BuildingHandler.cs" />
     <Compile Include="Injections\CampusHandler.cs" />

--- a/src/basegame/Helpers/VehicleSyncHelper.cs
+++ b/src/basegame/Helpers/VehicleSyncHelper.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+using CSM.API;
+using CSM.Commands.Data.Internal;
+using CSM.Networking;
+using ColossalFramework;
+using UnityEngine;
+
+namespace CSM.BaseGame.Helpers
+{
+    /// <summary>
+    ///     Helper to periodically sync vehicle positions from the server.
+    /// </summary>
+    public static class VehicleSyncHelper
+    {
+        public static void Send()
+        {
+            if (Command.CurrentRole != MultiplayerRole.Server)
+                return;
+
+            var list = new List<VehiclePositionCommand.VehicleData>();
+            VehicleManager vm = VehicleManager.instance;
+            var buffer = vm.m_vehicles.m_buffer;
+            for (ushort i = 1; i < buffer.Length; i++)
+            {
+                if ((buffer[i].m_flags & Vehicle.Flags.Created) != 0)
+                {
+                    list.Add(new VehiclePositionCommand.VehicleData
+                    {
+                        VehicleId = i,
+                        Position = buffer[i].GetLastFramePosition()
+                    });
+                }
+            }
+
+            if (list.Count > 0)
+            {
+                Command.SendToAll(new VehiclePositionCommand
+                {
+                    Vehicles = list
+                });
+            }
+        }
+    }
+}

--- a/src/csm/CSM.csproj
+++ b/src/csm/CSM.csproj
@@ -80,8 +80,9 @@
 		<Compile Include="Commands\Data\Internal\FinishTransactionCommand.cs" />
 		<Compile Include="Commands\Data\Internal\PlayerListCommand.cs" />
 		<Compile Include="Commands\Data\Internal\RequestWorldTransferCommand.cs" />
-		<Compile Include="Commands\Data\Internal\SlowdownCommand.cs" />
-		<Compile Include="Commands\Data\Internal\WorldTransferCommand.cs" />
+                <Compile Include="Commands\Data\Internal\SlowdownCommand.cs" />
+                <Compile Include="Commands\Data\Internal\VehiclePositionCommand.cs" />
+                <Compile Include="Commands\Data\Internal\WorldTransferCommand.cs" />
 		<Compile Include="Commands\Handler\Game\SpeedPauseReachedHandler.cs" />
 		<Compile Include="Commands\Handler\Game\SpeedPauseResponseHandler.cs" />
 		<Compile Include="Commands\Handler\Game\SpeedPauseRequestHandler.cs" />
@@ -95,8 +96,9 @@
 		<Compile Include="Commands\Handler\Internal\FinishTransactionHandler.cs" />
 		<Compile Include="Commands\Handler\Internal\PlayerListHandler.cs" />
 		<Compile Include="Commands\Handler\Internal\RequestWorldTransferHandler.cs" />
-		<Compile Include="Commands\Handler\Internal\SlowdownHandler.cs" />
-		<Compile Include="Commands\Handler\Internal\WorldTransferHandler.cs" />
+                <Compile Include="Commands\Handler\Internal\SlowdownHandler.cs" />
+                <Compile Include="Commands\Handler\Internal\VehiclePositionHandler.cs" />
+                <Compile Include="Commands\Handler\Internal\WorldTransferHandler.cs" />
 		<Compile Include="Container\ChatCommand.cs" />
 		<Compile Include="Container\ChirperMessage.cs" />
 		<Compile Include="Container\Tuple.cs" />

--- a/src/csm/Commands/Data/Internal/VehiclePositionCommand.cs
+++ b/src/csm/Commands/Data/Internal/VehiclePositionCommand.cs
@@ -1,0 +1,29 @@
+using CSM.API.Commands;
+using ProtoBuf;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace CSM.Commands.Data.Internal
+{
+    /// <summary>
+    ///     Periodically sends vehicle position updates from the server.
+    /// </summary>
+    /// Sent by:
+    /// - VehicleSyncHelper
+    [ProtoContract]
+    public class VehiclePositionCommand : CommandBase
+    {
+        [ProtoMember(1)]
+        public List<VehicleData> Vehicles { get; set; }
+
+        [ProtoContract]
+        public class VehicleData
+        {
+            [ProtoMember(1)]
+            public ushort VehicleId { get; set; }
+
+            [ProtoMember(2)]
+            public Vector3 Position { get; set; }
+        }
+    }
+}

--- a/src/csm/Commands/Handler/Internal/VehiclePositionHandler.cs
+++ b/src/csm/Commands/Handler/Internal/VehiclePositionHandler.cs
@@ -1,0 +1,32 @@
+using CSM.API.Commands;
+using CSM.Commands.Data.Internal;
+using ColossalFramework;
+using UnityEngine;
+
+namespace CSM.Commands.Handler.Internal
+{
+    public class VehiclePositionHandler : CommandHandler<VehiclePositionCommand>
+    {
+        public VehiclePositionHandler()
+        {
+            TransactionCmd = false;
+        }
+
+        protected override void Handle(VehiclePositionCommand command)
+        {
+            // Update vehicle positions on clients.
+            foreach (var data in command.Vehicles)
+            {
+                try
+                {
+                    ref Vehicle vehicle = ref VehicleManager.instance.m_vehicles.m_buffer[data.VehicleId];
+                    vehicle.SetPosition(data.Position);
+                }
+                catch
+                {
+                    // Ignore if vehicle does not exist or method fails.
+                }
+            }
+        }
+    }
+}

--- a/src/csm/Extensions/ThreadingExtension.cs
+++ b/src/csm/Extensions/ThreadingExtension.cs
@@ -5,6 +5,7 @@ using CSM.API.Commands;
 using CSM.API.Helpers;
 using CSM.API.Networking.Status;
 using CSM.BaseGame.Injections;
+using CSM.BaseGame.Helpers;
 using CSM.Commands;
 using CSM.Helpers;
 using CSM.Networking;
@@ -15,6 +16,7 @@ namespace CSM.Extensions
     public class ThreadingExtension : ThreadingExtensionBase
     {
         private DateTime _lastEconomyAndDropSync;
+        private DateTime _lastVehicleSync;
 
         public override void OnCreated(IThreading threading)
         {
@@ -58,6 +60,16 @@ namespace CSM.Extensions
                     SlowdownHelper.SendDroppedFrames();
                 }
                 _lastEconomyAndDropSync = DateTime.Now;
+            }
+
+            // Send vehicle position updates every five seconds
+            if (DateTime.Now.Subtract(_lastVehicleSync).TotalSeconds > 5)
+            {
+                if (MultiplayerManager.Instance.IsConnected())
+                {
+                    VehicleSyncHelper.Send();
+                }
+                _lastVehicleSync = DateTime.Now;
             }
 
             // Finish transactions


### PR DESCRIPTION
## Summary
- add VehicleSyncHelper and command to periodically broadcast vehicle positions
- invoke new helper from ThreadingExtension
- handle VehiclePositionCommand on clients
- document current sync limitations in README

## Testing
- `dotnet build CSM.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68419a67fff483288f8435f9dc9cdf32